### PR TITLE
Feature/GitHub Zen tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ npm start
 ### Tools
 
 - `hello`: Says hello to someone (uses MCP_GREETING)
+- `get_github_zen`: Get a Zen of GitHub quote from the GitHub API
 
 ### Resources
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-typescript-starter",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-typescript-starter",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.19.1",
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.19.1.tgz",
-      "integrity": "sha512-3Y2h3MZKjec1eAqSTBclATlX+AbC6n1LgfVzRMJLt3v6w0RCYgwLrjbxPDbhsYHt6Wdqc/aCceNJYgj448ELQQ==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.20.0.tgz",
+      "integrity": "sha512-kOQ4+fHuT4KbR2iq2IjeV32HiihueuOf1vJkq18z08CLZ1UQrTc8BXJpVfxZkq45+inLLD+D4xx4nBjUelJa4Q==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { registerHelloTool } from "./tools.js";
+import { registerHelloTool, registerGitHubZenTool } from "./tools.js";
 import { registerExampleResource } from "./resources.js";
 import { registerExamplePrompt } from "./prompts.js";
 
@@ -12,6 +12,7 @@ export async function startServer({ greeting, secret }: { greeting: string; secr
 
   // Register tool, resource, and prompt
   registerHelloTool(server, greeting);
+  registerGitHubZenTool(server);
   registerExampleResource(server);
   registerExamplePrompt(server);
 

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -16,8 +16,42 @@ export function defineHelloTool(greeting: string) {
   };
 }
 
+export function defineGitHubZenTool() {
+  return {
+    name: "get_github_zen",
+    description: "Get a Zen of GitHub quote from the GitHub API.",
+    schema: {},
+    handler: async (_params: {}, _extra: any) => {
+      try {
+        const response = await fetch("https://api.github.com/zen");
+        if (!response.ok) {
+          throw new Error(`HTTP error! status: ${response.status}`);
+        }
+        const zenQuote = await response.text();
+        return {
+          content: [
+            { type: "text" as const, text: zenQuote }
+          ]
+        };
+      } catch (error) {
+        return {
+          content: [
+            { type: "text" as const, text: `Error fetching GitHub Zen quote: ${error instanceof Error ? error.message : 'Unknown error'}` }
+          ]
+        };
+      }
+    },
+  };
+}
+
 // Register the hello tool with the server
 export function registerHelloTool(server: McpServer, greeting: string) {
   const { name, description, schema, handler } = defineHelloTool(greeting);
+  server.tool(name, description, schema, handler);
+}
+
+// Register the GitHub Zen tool with the server
+export function registerGitHubZenTool(server: McpServer) {
+  const { name, description, schema, handler } = defineGitHubZenTool();
   server.tool(name, description, schema, handler);
 }

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,4 +1,4 @@
-const { defineHelloTool } = require('./lib/tools');
+const { defineHelloTool, defineGitHubZenTool } = require('./lib/tools');
 const { defineExampleResource } = require('./lib/resources');
 const { defineExamplePrompt } = require('./lib/prompts');
 
@@ -19,5 +19,13 @@ describe('MCP Server', () => {
     const promptDef = defineExamplePrompt();
     const result = promptDef.handler({ name: 'Alice' }, {});
     expect(result.messages[0].content.text).toContain('Alice');
+  });
+
+  it('github zen tool returns a quote', async () => {
+    const toolDef = defineGitHubZenTool();
+    const result = await toolDef.handler({}, {});
+    expect(result.content[0].text).toBeTruthy();
+    expect(typeof result.content[0].text).toBe('string');
+    expect(result.content[0].text.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
This pull request adds a new tool for fetching a Zen of GitHub quote from the GitHub API, updates the server to register this tool, and improves test coverage to include the new functionality. The main changes are grouped below:

**New GitHub Zen tool integration:**

* Added `defineGitHubZenTool` and `registerGitHubZenTool` to `src/lib/tools.ts`, which defines and registers a tool that fetches a Zen quote from the GitHub API and returns it as text.
* Registered the new tool in the server startup logic in `src/lib/server.ts` so it is available when the server runs. [[1]](diffhunk://#diff-51d82a57974c308e63bb067081b8a1f46af5b01943a736cd67f2d2ce4f8debb3L3-R3) [[2]](diffhunk://#diff-51d82a57974c308e63bb067081b8a1f46af5b01943a736cd67f2d2ce4f8debb3R15)

**Documentation update:**

* Updated the `README.md` to document the new `get_github_zen` tool.

**Testing:**

* Added a test for the GitHub Zen tool in `src/test.ts` to ensure it returns a non-empty string quote. [[1]](diffhunk://#diff-81188fa6e8155e286766a6f3ca74e3eaf1e65e4aca7c0c2788e588b32c591288L1-R1) [[2]](diffhunk://#diff-81188fa6e8155e286766a6f3ca74e3eaf1e65e4aca7c0c2788e588b32c591288R23-R30)