### PR TITLE
Add programming survey tool and register it with the server

### DIFF
--- a/src/lib/elicitations.ts
+++ b/src/lib/elicitations.ts
@@ -1,0 +1,128 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  ElicitRequest,
+  ElicitResultSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+
+export function defineProgrammingSurvey() {
+  return {
+    name: "programming_favorites_survey",
+    description:
+      "Demonstrates the Elicitation feature by asking the user to provide information about their programming background.",
+    schema: {},
+    handler: async (_args: any, extra: any) => {
+      try {
+        // Helper function to request elicitation from the client
+        const requestElicitation = async (
+          message: string,
+          requestedSchema: any,
+          sendRequest: any
+        ) => {
+          const request: ElicitRequest = {
+            method: "elicitation/create",
+            params: {
+              message,
+              requestedSchema,
+            },
+          };
+
+          return await sendRequest(request, ElicitResultSchema);
+        };
+
+        const elicitationResult = await requestElicitation(
+          "Please tell us about your programming background!",
+          {
+            type: "object",
+            properties: {
+              programmingLanguage: {
+                type: "string",
+                enum: ["TypeScript", "JavaScript", "Python", "Java", "Go"],
+                description: "Your preferred programming language",
+              },
+              experienceLevel: {
+                type: "string",
+                enum: ["Beginner", "Intermediate", "Advanced", "Expert"],
+                description: "Your programming experience level",
+              },
+            },
+            required: ["programmingLanguage", "experienceLevel"],
+          },
+          extra.sendRequest
+        );
+
+        const content = [];
+
+        if (
+          elicitationResult.action === "accept" &&
+          elicitationResult.content
+        ) {
+          content.push({
+            type: "text" as const,
+            text: `✅ Thank you for sharing your preferences!`,
+          });
+
+          const { programmingLanguage, experienceLevel } =
+            elicitationResult.content;
+          content.push({
+            type: "text" as const,
+            text: `Here's your programming background:\n- Programming Language: ${
+              programmingLanguage || "not specified"
+            }\n- Experience Level: ${experienceLevel || "not specified"}`,
+          });
+        } else if (elicitationResult.action === "decline") {
+          content.push({
+            type: "text" as const,
+            text: `❌ You declined to share your preferences.`,
+          });
+        } else if (elicitationResult.action === "cancel") {
+          content.push({
+            type: "text" as const,
+            text: `⚠️ You cancelled the survey.`,
+          });
+        }
+
+        // Include raw result for debugging
+        content.push({
+          type: "text" as const,
+          text: `\nRaw result: ${JSON.stringify(elicitationResult, null, 2)}`,
+        });
+
+        return { content };
+      } catch (error) {
+        // Clean error handling - just report what happened
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+
+        if (
+          errorMessage.includes("not supported") ||
+          errorMessage.includes("not available")
+        ) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: `Elicitation is not yet supported by your MCP client! ✨`,
+              },
+            ],
+          };
+        }
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `❌ Survey error: ${errorMessage}`,
+            },
+          ],
+        };
+      }
+    },
+  };
+}
+
+// Register the survey tool with the server
+export function registerProgrammingSurvey(server: McpServer) {
+  const { name, description, schema, handler } = defineProgrammingSurvey();
+  server.tool(name, description, schema, handler);
+}

--- a/src/lib/elicitations.ts
+++ b/src/lib/elicitations.ts
@@ -72,12 +72,6 @@ export function defineProgrammingSurvey() {
           });
         }
 
-        // Include raw result for debugging
-        content.push({
-          type: "text" as const,
-          text: `\nRaw result: ${JSON.stringify(elicitationResult, null, 2)}`,
-        });
-
         return { content };
       } catch (error) {
         // Clean error handling - just report what happened

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { registerHelloTool, registerGitHubZenTool } from "./tools.js";
 import { registerExampleResource } from "./resources.js";
 import { registerExamplePrompt } from "./prompts.js";
+import { registerProgrammingSurvey } from "./elicitations.js";
 
 export async function startServer({ greeting, secret }: { greeting: string; secret: string }) {
   const server = new McpServer({
@@ -15,6 +16,7 @@ export async function startServer({ greeting, secret }: { greeting: string; secr
   registerGitHubZenTool(server);
   registerExampleResource(server);
   registerExamplePrompt(server);
+  registerProgrammingSurvey(server);
 
   // Start stdio transport
   const transport = new StdioServerTransport();


### PR DESCRIPTION
This pull request introduces a new survey feature to the MCP server that demonstrates the elicitation capability by asking users about their programming background. The main change is the addition of a new tool that interacts with users, collects their preferences, and handles various response scenarios. The survey tool is registered with the server so it can be used alongside existing tools.

**New survey feature:**

* Added `defineProgrammingSurvey` and `registerProgrammingSurvey` functions in `src/lib/elicitations.ts` to implement an elicitation-based survey for collecting users' preferred programming language and experience level, including handling for accept, decline, and cancel actions, and error cases.

**Integration with server startup:**

* Imported `registerProgrammingSurvey` in `src/lib/server.ts` to make the survey tool available for registration.
* Registered the programming survey tool in the server initialization function to ensure it is available when the server starts.